### PR TITLE
Fix deposit display in overview

### DIFF
--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/dashboard/OverviewFragment.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/dashboard/OverviewFragment.kt
@@ -70,7 +70,7 @@ class OverviewFragment: BaseFragment() {
                     it.second.getTransaction()?.data?.forEachIndexed { _, element ->
                         depositSum += Math.abs(element.attributes.amount.toInt())
                     }
-                    incomeDigit.text = withdrawSum.toString()
+                    incomeDigit.text = depositSum.toString()
                 }
             } else {
                 isThereError = true


### PR DESCRIPTION
The overview on the dashboard is currently showing the wrong number for the deposit sum (it's using the withdrawal sum). Looks like a copy-and-paste mistake. :wink: 