### PR TITLE
Update attachment endpoint for new API

### DIFF
--- a/app/src/main/java/xyz/hisname/fireflyiii/repository/models/attachment/Attributes.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/repository/models/attachment/Attributes.kt
@@ -28,7 +28,7 @@ data class Attributes(
         val attachable_id: Int,
         val attachable_type: String,
         val created_at: String,
-        val download_uri: Uri,
+        val download_url: Uri,
         val filename: String,
         val md5: String,
         val mime: String,
@@ -36,5 +36,5 @@ data class Attributes(
         val size: Int,
         val title: String,
         val updated_at: String,
-        val upload_uri: String
+        val upload_url: String
 )

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/details/TransactionDetailsFragment.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/details/TransactionDetailsFragment.kt
@@ -269,7 +269,7 @@ class TransactionDetailsFragment: BaseDetailFragment() {
     private fun duplicateTransaction(){
         val attachmentUri = arrayListOf<Uri>()
         attachmentDataAdapter.forEach {  attachmentData ->
-            attachmentUri.add(attachmentData.attachmentAttributes.download_uri)
+            attachmentUri.add(attachmentData.attachmentAttributes.download_url)
         }
         transactionDetailsViewModel.duplicationTransactionByJournalId(transactionJournalId,
             attachmentUri).observe(viewLifecycleOwner){ message ->

--- a/app/src/main/java/xyz/hisname/fireflyiii/util/extension/DownloadExtension.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/util/extension/DownloadExtension.kt
@@ -29,7 +29,7 @@ import java.io.File
 
 fun Application.downloadFile(accessToken: String, attachmentData: AttachmentData, fileToOpen: File){
     val downloadManager = this.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-    val request = DownloadManager.Request(attachmentData.attachmentAttributes.download_uri)
+    val request = DownloadManager.Request(attachmentData.attachmentAttributes.download_url)
     request.addRequestHeader("Authorization", "Bearer $accessToken")
     request.setTitle("Downloading " + attachmentData.attachmentAttributes.filename)
     val sharedPref = PreferenceManager.getDefaultSharedPreferences(this)


### PR DESCRIPTION
With Firefly-iii 5.6.1, the attachment endpoint returns *_url instead of the old *_uri parameters.
This causes uploading attachments to not work.

Fixes # (issue)

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Translation
