### PR TITLE
Fix #171 PAT Login Fail with Self Signed Certificate

### DIFF
--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/onboarding/PatFragment.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/onboarding/PatFragment.kt
@@ -40,7 +40,7 @@ class PatFragment: Fragment() {
 
     private val sharedPref by lazy { PreferenceManager.getDefaultSharedPreferences(requireContext()) }
     private val authViewModel by lazy { getViewModel(AuthActivityViewModel::class.java) }
-    private lateinit var fileUri: Uri
+    private var fileUri: Uri? = null
     private lateinit var chooseDocument: ActivityResultLauncher<Array<String>>
     private var fragmentPatBinding: FragmentPatBinding? = null
     private val binding get() = fragmentPatBinding!!
@@ -64,7 +64,7 @@ class PatFragment: Fragment() {
             if(fileChoosen != null){
                 fileUri = fileChoosen
                 binding.certPath.isVisible = true
-                binding.certPath.text = FileUtils.getPathFromUri(requireContext(), fileUri)
+                binding.certPath.text = FileUtils.getPathFromUri(requireContext(), fileChoosen)
             } else {
                 binding.selfSignedCheckbox.isChecked = false
             }
@@ -75,7 +75,7 @@ class PatFragment: Fragment() {
         binding.fireflySignIn.setOnClickListener {
             hideKeyboard()
             authViewModel.authViaPat(binding.fireflyUrlEdittext.getString(),
-                    binding.fireflyAccessEdittext.getString(), binding.certPath.text.toString().toUri())
+                    binding.fireflyAccessEdittext.getString(), fileUri)
         }
     }
 


### PR DESCRIPTION
Fixes #171

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Translation

## Details

App crashes when logging in with personal access token with a self signed certificate. 

```
STACK_TRACE=java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:506)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
	... 1 more
Caused by: java.io.FileNotFoundException: No content provider: /storage/emulated/0/Download/firefly_selfsigned.pem
...
```

OAuth login still works with self signed certificate so copied the changes from `LoginFragment`.