### PR TITLE
Correct usage of RecyclerView

### DIFF
--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/account/AccountRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/account/AccountRecyclerAdapter.kt
@@ -32,57 +32,54 @@ import xyz.hisname.fireflyiii.util.extension.getCompatColor
 import java.math.BigDecimal
 
 class AccountRecyclerAdapter(private val clickListener:(AccountData) -> Unit):
-        PagingDataAdapter<AccountData, AccountRecyclerAdapter.AccountViewHolder>(DIFF_CALLBACK){
-
+        PagingDataAdapter<AccountData, AccountRecyclerAdapter.AccountViewHolder>(DIFF_CALLBACK) {
     private lateinit var context: Context
-    private var accountListItemBinding: AccountListItemBinding? = null
-    private val binding get() = accountListItemBinding!!
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AccountViewHolder {
         context = parent.context
-        accountListItemBinding = AccountListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return AccountViewHolder(binding)
+        val itemView = AccountListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return AccountViewHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: AccountViewHolder, position: Int){
         getItem(position)?.let{
             holder.bind(it, clickListener)
         }
-        // setIsRecyclable MUST BE SET TO false otherwise duplicate items will be shown
-        holder.setIsRecyclable(false)
     }
 
-    inner class AccountViewHolder(itemView: AccountListItemBinding): RecyclerView.ViewHolder(itemView.root) {
+    inner class AccountViewHolder(
+        private val accountView: AccountListItemBinding
+    ): RecyclerView.ViewHolder(accountView.root) {
         fun bind(data: AccountData, clickListener: (AccountData) -> Unit){
             val accountData = data.accountAttributes
             var currencySymbol = ""
             if(!accountData.active){
-                binding.accountNameText.setTextColor(context.getCompatColor(R.color.material_grey_600))
-                binding.accountNumberText.setTextColor(context.getCompatColor(R.color.material_grey_600))
+                accountView.accountNameText.setTextColor(context.getCompatColor(R.color.material_grey_600))
+                accountView.accountNumberText.setTextColor(context.getCompatColor(R.color.material_grey_600))
             }
             if(accountData.currency_symbol != null){
                 currencySymbol = accountData.currency_symbol
             }
             if(accountData.account_number != null){
-                binding.accountNumberText.text = accountData.account_number
+                accountView.accountNumberText.text = accountData.account_number
             } else {
-                binding.accountNumberText.isVisible = false
+                accountView.accountNumberText.isVisible = false
             }
             val isPending = data.accountAttributes.isPending
             if(isPending){
-                binding.accountNameText.text = accountData.name + " (Pending)"
-                binding.accountNameText.setTextColor(context.getCompatColor(R.color.md_red_500))
+                accountView.accountNameText.text = accountData.name + " (Pending)"
+                accountView.accountNameText.setTextColor(context.getCompatColor(R.color.md_red_500))
             } else {
-                binding.accountNameText.text = accountData.name
+                accountView.accountNameText.text = accountData.name
             }
             val amount = accountData.current_balance
             if(amount < BigDecimal.ZERO){
-                binding.accountAmountText.setTextColor(context.getCompatColor(R.color.md_red_500))
+                accountView.accountAmountText.setTextColor(context.getCompatColor(R.color.md_red_500))
             } else if(amount > BigDecimal.ZERO){
-                binding.accountAmountText.setTextColor(context.getCompatColor(R.color.md_green_500))
+                accountView.accountAmountText.setTextColor(context.getCompatColor(R.color.md_green_500))
             }
-            binding.accountAmountText.text = currencySymbol + " " + amount
-            binding.accountId.text = data.accountId.toString()
+            accountView.accountAmountText.text = currencySymbol + " " + amount
+            accountView.accountId.text = data.accountId.toString()
             itemView.setOnClickListener { clickListener(data) }
         }
     }

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/base/AttachmentRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/base/AttachmentRecyclerAdapter.kt
@@ -39,24 +39,23 @@ class AttachmentRecyclerAdapter(private val items: MutableList<AttachmentData>,
         RecyclerView.Adapter<AttachmentRecyclerAdapter.AttachmentAdapter>() {
 
     private lateinit var context: Context
-    private var transactionAttachmentItemsBinding: TransactionAttachmentItemsBinding? = null
-    private val binding get() = transactionAttachmentItemsBinding!!
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AttachmentAdapter {
         context = parent.context
-        transactionAttachmentItemsBinding = TransactionAttachmentItemsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return AttachmentAdapter(binding)
-
+        val itemView = TransactionAttachmentItemsBinding.inflate(LayoutInflater.from(context), parent, false)
+        return AttachmentAdapter(itemView)
     }
 
     override fun getItemCount() = items.size
 
     override fun onBindViewHolder(holder: AttachmentAdapter, position: Int) = holder.bind(items[position], clickListener, position)
 
-    inner class AttachmentAdapter(view: TransactionAttachmentItemsBinding): RecyclerView.ViewHolder(view.root) {
+    inner class AttachmentAdapter(
+        private val view: TransactionAttachmentItemsBinding
+    ): RecyclerView.ViewHolder(view.root) {
         fun bind(attachmentData: AttachmentData, clickListener: (AttachmentData) -> Unit, removeItemListener: Int){
             val fileName = attachmentData.attachmentAttributes.filename
-            binding.attachmentName.text = fileName
+            view.attachmentName.text = fileName
             if(shouldShowDownload) {
                 val downloadedFile = File(context.getExternalFilesDir(null).toString() + File.separator + fileName)
                 if (downloadedFile.exists()) {
@@ -64,22 +63,22 @@ class AttachmentRecyclerAdapter(private val items: MutableList<AttachmentData>,
                         icon = GoogleMaterial.Icon.gmd_folder_open
                         colorRes = R.color.md_yellow_700
                         sizeDp = 12
-                    }).into(binding.downloadButton)
+                    }).into(view.downloadButton)
                 } else {
                     Glide.with(context).load(IconicsDrawable(context).apply {
                         icon = GoogleMaterial.Icon.gmd_file_download
                         colorRes = R.color.md_green_500
                         sizeDp = 12
-                    }).into(binding.downloadButton)
+                    }).into(view.downloadButton)
                 }
             } else {
-                binding.downloadButton.setImageDrawable(IconicsDrawable(context, GoogleMaterial.Icon.gmd_close).apply {
+                view.downloadButton.setImageDrawable(IconicsDrawable(context, GoogleMaterial.Icon.gmd_close).apply {
                     colorRes = R.color.md_red_500
                     sizeDp = 12
                 })
-                binding.downloadButton.setOnClickListener { removeItemListener(removeItemListener) }
+                view.downloadButton.setOnClickListener { removeItemListener(removeItemListener) }
             }
-            binding.downloadButton.setOnClickListener { clickListener(attachmentData) }
+            view.downloadButton.setOnClickListener { clickListener(attachmentData) }
             itemView.setOnClickListener { clickListener(attachmentData) }
         }
     }

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsRecyclerAdapter.kt
@@ -34,13 +34,11 @@ class BillsRecyclerAdapter(private val clickListener:(BillData) -> Unit):
         PagingDataAdapter<BillData, BillsRecyclerAdapter.BillsHolder>(DIFF_CALLBACK) {
 
     private lateinit var context: Context
-    private var billsListItemBinding: BillsListItemBinding? = null
-    private val binding get() = billsListItemBinding!!
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BillsHolder {
         context = parent.context
-        billsListItemBinding = BillsListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return BillsHolder(binding)
+        val itemView = BillsListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return BillsHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: BillsHolder, position: Int) {
@@ -49,29 +47,31 @@ class BillsRecyclerAdapter(private val clickListener:(BillData) -> Unit):
         }
     }
 
-    inner class BillsHolder(itemView: BillsListItemBinding): RecyclerView.ViewHolder(itemView.root) {
+    inner class BillsHolder(
+        private val billView: BillsListItemBinding
+    ): RecyclerView.ViewHolder(billView.root) {
         fun bind(billData: BillData, clickListener: (BillData) -> Unit){
             val billResponse = billData.billAttributes
             var billName = billResponse.name
             val isPending = billResponse.isPending
             if(isPending){
                 billName = "$billName (Pending)"
-                binding.billName.setTextColor(context.getCompatColor(R.color.md_red_500))
+                billView.billName.setTextColor(context.getCompatColor(R.color.md_red_500))
             }
-            binding.billName.text = billName
+            billView.billName.text = billName
             val amountToDisplay = billResponse.amount_max
                     .plus(billResponse.amount_min)
                     .div(BigDecimal.valueOf(2))
-            binding.billAmount.text = context.getString(R.string.bill_amount,
+            billView.billAmount.text = context.getString(R.string.bill_amount,
                     billResponse.currency_symbol, amountToDisplay)
             val freq = billResponse.repeat_freq
-            binding.billFreq.text = freq.substring(0,1).toUpperCase() + freq.substring(1)
+            billView.billFreq.text = freq.substring(0,1).toUpperCase() + freq.substring(1)
 
             val nextMatch = billResponse.next_expected_match
             if(nextMatch != null){
-                binding.billNextDueDate.text = billResponse.next_expected_match
+                billView.billNextDueDate.text = billResponse.next_expected_match
             }
-            binding.billId.text = billData.billId.toString()
+            billView.billId.text = billData.billId.toString()
             itemView.setOnClickListener{clickListener(billData)}
         }
     }

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsStatusRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsStatusRecyclerAdapter.kt
@@ -34,14 +34,12 @@ import xyz.hisname.fireflyiii.repository.models.bills.BillsStatusModel
 
 class BillsStatusRecyclerAdapter(private val billStatus: List<BillsStatusModel>): RecyclerView.Adapter<BillsStatusRecyclerAdapter.BillsStatusHolder>() {
 
-    private var billDialogRecyclerBinding: BillDialogRecyclerViewBinding? = null
-    private val binding get() = billDialogRecyclerBinding!!
     private lateinit var context: Context
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BillsStatusHolder {
         context = parent.context
-        billDialogRecyclerBinding = BillDialogRecyclerViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return BillsStatusHolder(binding)
+        val itemView = BillDialogRecyclerViewBinding.inflate(LayoutInflater.from(context), parent, false)
+        return BillsStatusHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: BillsStatusHolder, position: Int) {
@@ -50,25 +48,27 @@ class BillsStatusRecyclerAdapter(private val billStatus: List<BillsStatusModel>)
 
     override fun getItemCount() = billStatus.size
 
-    inner class BillsStatusHolder(itemView: BillDialogRecyclerViewBinding): RecyclerView.ViewHolder(itemView.root) {
+    inner class BillsStatusHolder(
+        private val view: BillDialogRecyclerViewBinding
+    ): RecyclerView.ViewHolder(view.root) {
         fun bind(billStatusModel: BillsStatusModel) {
-            binding.billName.text = billStatusModel.billName
-            binding.billAmount.text = context.getString(R.string.bill_amount,
+            view.billName.text = billStatusModel.billName
+            view.billAmount.text = context.getString(R.string.bill_amount,
                     billStatusModel.billCurrency, billStatusModel.billAmount)
             if(billStatusModel.isBillPaid){
-                binding.billStatusImage.setImageDrawable(IconicsDrawable(context).apply {
+                view.billStatusImage.setImageDrawable(IconicsDrawable(context).apply {
                     icon = GoogleMaterial.Icon.gmd_check
                     color = IconicsColor.colorInt(context.getColor(R.color.md_green_500))
                     sizeDp = 24
                 })
             } else {
-                binding.billStatusImage.setImageDrawable(IconicsDrawable(context).apply {
+                view.billStatusImage.setImageDrawable(IconicsDrawable(context).apply {
                     icon = FontAwesome.Icon.faw_info_circle
                     color = IconicsColor.colorInt(context.getColor(R.color.md_red_500))
                     sizeDp = 24
                 })
             }
-            binding.billId.text = billStatusModel.billId.toString()
+            view.billId.text = billStatusModel.billId.toString()
         }
     }
 }

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsToPayRecyclerView.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/bills/BillsToPayRecyclerView.kt
@@ -30,16 +30,13 @@ import java.math.BigDecimal
 class BillsToPayRecyclerView(private val budgetData: List<BillData>,
                              private val clickListener:(BillData) -> Unit):
         RecyclerView.Adapter<BillsToPayRecyclerView.BillsToPayHolder>() {
-
     private lateinit var context: Context
-    private var billsToPayItemBinding: BillsToPayItemBinding? = null
-    private val binding get() = billsToPayItemBinding!!
 
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BillsToPayHolder {
         context = parent.context
-        billsToPayItemBinding = BillsToPayItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return BillsToPayHolder(binding)
+        val itemView = BillsToPayItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return BillsToPayHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: BillsToPayHolder, position: Int) {
@@ -48,17 +45,19 @@ class BillsToPayRecyclerView(private val budgetData: List<BillData>,
 
     override fun getItemCount() = budgetData.size
 
-    inner class BillsToPayHolder(itemView: BillsToPayItemBinding): RecyclerView.ViewHolder(itemView.root) {
-        fun bind(billData: BillData, clickListener: (BillData) -> Unit){
+    inner class BillsToPayHolder(
+        private val view: BillsToPayItemBinding
+    ): RecyclerView.ViewHolder(view.root) {
+        fun bind(billData: BillData, clickListener: (BillData) -> Unit) {
             val billResponse = billData.billAttributes
             val billName = billResponse.name
             val amountToDisplay = billResponse.amount_max
                     .plus(billResponse.amount_min)
                     .div(BigDecimal.valueOf(2))
-            binding.billName.text = billName
-            binding.billAmount.text = context.getString(R.string.bill_amount,
+            view.billName.text = billName
+            view.billAmount.text = context.getString(R.string.bill_amount,
                     billResponse.currency_symbol, amountToDisplay)
-            binding.root.setOnClickListener{clickListener(billData)}
+            view.root.setOnClickListener{clickListener(billData)}
         }
     }
 }

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/categories/CategoriesRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/categories/CategoriesRecyclerAdapter.kt
@@ -30,28 +30,27 @@ import xyz.hisname.fireflyiii.repository.models.category.CategoryData
 class CategoriesRecyclerAdapter(private val clickListener:(CategoryData) -> Unit):
         PagingDataAdapter<CategoryData, CategoriesRecyclerAdapter.CategoryHolder>(DIFF_CALLBACK) {
 
-    private lateinit var context: Context
-    private var categoryListItemBinding: CategoryListItemBinding? = null
-    private val binding get() = categoryListItemBinding!!
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryHolder {
-        context = parent.context
-        categoryListItemBinding = CategoryListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return CategoryHolder(binding)
+        val context = parent.context
+        val itemView = CategoryListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return CategoryHolder(itemView)
     }
 
-    override fun onBindViewHolder(holder: CategoryHolder, position: Int){
+    override fun onBindViewHolder(holder: CategoryHolder, position: Int) {
         getItem(position)?.let{
             holder.bind(it, clickListener)
         }
     }
 
-    inner class CategoryHolder(itemView: CategoryListItemBinding): RecyclerView.ViewHolder(itemView.root) {
+    inner class CategoryHolder(
+        private val categoryView: CategoryListItemBinding
+    ): RecyclerView.ViewHolder(categoryView.root) {
+
         fun bind(categoryData: CategoryData, clickListener: (CategoryData) -> Unit) {
             val categoryDataSet = categoryData.categoryAttributes
-            binding.categoryName.text = categoryDataSet.name
-            binding.categoryId.text = categoryData.categoryId.toString()
-            binding.root.setOnClickListener { clickListener(categoryData) }
+            categoryView.categoryName.text = categoryDataSet.name
+            categoryView.categoryId.text = categoryData.categoryId.toString()
+            categoryView.root.setOnClickListener { clickListener(categoryData) }
         }
     }
 

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/currency/CurrencyRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/currency/CurrencyRecyclerAdapter.kt
@@ -48,13 +48,11 @@ class CurrencyRecyclerAdapter(private val shouldShowDisabled: Boolean = true,
         }
         AppPref(context.getSharedPreferences("$uniqueHash-user-preferences", Context.MODE_PRIVATE)).isCurrencyThumbnailEnabled
     }
-    private var currencyListBinding: CurrencyListBinding? = null
-    private val binding get() = currencyListBinding!!
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CurrencyHolder {
         context = parent.context
-        currencyListBinding = CurrencyListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return CurrencyHolder(binding)
+        val itemView = CurrencyListBinding.inflate(LayoutInflater.from(context), parent, false)
+        return CurrencyHolder(itemView)
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -67,25 +65,27 @@ class CurrencyRecyclerAdapter(private val shouldShowDisabled: Boolean = true,
         }
     }
 
-    inner class CurrencyHolder(itemView: CurrencyListBinding): RecyclerView.ViewHolder(itemView.root){
+    inner class CurrencyHolder(
+        private val currencyView: CurrencyListBinding
+    ): RecyclerView.ViewHolder(currencyView.root){
         fun bind(currencyData: CurrencyData, clickListener: (CurrencyData) -> Unit){
             val currency = currencyData.currencyAttributes
-            binding.currencySymbol.text = currency.symbol
-            binding.currencyCode.text = currency.code
+            currencyView.currencySymbol.text = currency.symbol
+            currencyView.currencyCode.text = currency.code
             if(shouldShowDisabled){
                 if(!currency.enabled){
-                    binding.currencyName.text = currency.name + " (" + currency.code + ")" + " (Disabled)"
-                    binding.currencyName.setTextColor(context.getCompatColor(R.color.md_grey_400))
-                    binding.currencySymbol.setTextColor(context.getCompatColor(R.color.md_grey_400))
+                    currencyView.currencyName.text = currency.name + " (" + currency.code + ")" + " (Disabled)"
+                    currencyView.currencyName.setTextColor(context.getCompatColor(R.color.md_grey_400))
+                    currencyView.currencySymbol.setTextColor(context.getCompatColor(R.color.md_grey_400))
                 }
             }
-            binding.currencyName.text = currency.name + " (" + currency.code + ")"
+            currencyView.currencyName.text = currency.name + " (" + currency.code + ")"
             if(isThumbnailEnabled) {
-                binding.flagImage.isVisible = true
+                currencyView.flagImage.isVisible = true
                 Glide.with(context)
                         .load(Flags.getFlagByIso(currency.code))
                         .error(R.drawable.unknown)
-                        .into(binding.flagImage)
+                        .into(currencyView.flagImage)
             }
             itemView.setOnClickListener {
                 clickListener(currencyData)

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/piggybank/PiggyRecyclerAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/piggybank/PiggyRecyclerAdapter.kt
@@ -35,16 +35,12 @@ import kotlin.math.abs
 
 class PiggyRecyclerAdapter(private val clickListener:(PiggyData) -> Unit):
         PagingDataAdapter<PiggyData, PiggyRecyclerAdapter.PiggyHolder>(DIFF_CALLBACK){
-
     private lateinit var context: Context
-    private var piggyListItemBinding: PiggyListItemBinding? = null
-    private val binding get() = piggyListItemBinding!!
-
-
+    
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PiggyHolder {
         context = parent.context
-        piggyListItemBinding = PiggyListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PiggyHolder(binding)
+        val itemView = PiggyListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return PiggyHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: PiggyHolder, position: Int){
@@ -54,7 +50,9 @@ class PiggyRecyclerAdapter(private val clickListener:(PiggyData) -> Unit):
     }
 
 
-    inner class PiggyHolder(itemView: PiggyListItemBinding): RecyclerView.ViewHolder(itemView.root) {
+    inner class PiggyHolder(
+        private val piggyView: PiggyListItemBinding
+    ): RecyclerView.ViewHolder(piggyView.root) {
         fun bind(piggyData: PiggyData, clickListener: (PiggyData) -> Unit){
             val piggyBankData = piggyData.piggyAttributes
             var piggyBankName = piggyBankData.name
@@ -63,26 +61,26 @@ class PiggyRecyclerAdapter(private val clickListener:(PiggyData) -> Unit):
                 piggyBankName = piggyBankName.substring(0,17) + "..."
             }
             if(isPending){
-                binding.piggyName.setTextColor(context.getCompatColor(R.color.md_red_500))
+                piggyView.piggyName.setTextColor(context.getCompatColor(R.color.md_red_500))
                 piggyBankName = "$piggyBankName (Pending)"
             }
-            binding.piggyName.text = piggyBankName
-            binding.goalSave.text = piggyBankData.currency_symbol + " " + piggyBankData.current_amount + " / "  +
+            piggyView.piggyName.text = piggyBankName
+            piggyView.goalSave.text = piggyBankData.currency_symbol + " " + piggyBankData.current_amount + " / "  +
                     piggyBankData.currency_symbol + " " + piggyBankData.target_amount.toString()
             val percentage = piggyBankData.percentage ?: 0
             if(percentage <= 15){
-                binding.goalProgressBar.progressDrawable.colorFilter =
+                piggyView.goalProgressBar.progressDrawable.colorFilter =
                         BlendModeColorFilterCompat.createBlendModeColorFilterCompat(context.getCompatColor(R.color.md_red_700),
                                 BlendModeCompat.SRC_ATOP)
             } else if(percentage <= 50){
-                binding.goalProgressBar.progressDrawable.colorFilter =
+                piggyView.goalProgressBar.progressDrawable.colorFilter =
                         BlendModeColorFilterCompat.createBlendModeColorFilterCompat(context.getCompatColor(R.color.md_green_500),
                         BlendModeCompat.SRC_ATOP)
             }
-            binding.currentlySaved.text = percentage.toString() + "%"
-            binding.goalProgressBar.progress = percentage
+            piggyView.currentlySaved.text = percentage.toString() + "%"
+            piggyView.goalProgressBar.progress = percentage
             val targetDate = piggyBankData.target_date
-            binding.timeLeft.let {
+            piggyView.timeLeft.let {
                 if(!targetDate.isNullOrBlank()){
                     if(piggyBankData.percentage != 100){
                         val daysDiff = DateTimeUtil.getDaysDifference(targetDate).toInt()
@@ -104,8 +102,8 @@ class PiggyRecyclerAdapter(private val clickListener:(PiggyData) -> Unit):
                     it.text = "No target Date"
                 }
             }
-            binding.piggyId.text = piggyData.piggyId.toString()
-            binding.piggyCard.setOnClickListener{clickListener(piggyData)}
+            piggyView.piggyId.text = piggyData.piggyId.toString()
+            piggyView.piggyCard.setOnClickListener{clickListener(piggyData)}
         }
     }
 

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionAdapter.kt
@@ -34,15 +34,12 @@ import xyz.hisname.fireflyiii.util.getUniqueHash
 
 class TransactionAdapter(private val clickListener:(Transactions) -> Unit):
         PagingDataAdapter<Transactions, TransactionAdapter.TransactionViewHolder>(DIFF_CALLBACK) {
-
     private lateinit var context: Context
-    private var recentTransactionListBinding: RecentTransactionListBinding? = null
-    private val binding get() = recentTransactionListBinding!!
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TransactionViewHolder {
         context = parent.context
-        recentTransactionListBinding = RecentTransactionListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return TransactionViewHolder(binding)
+        val itemView = RecentTransactionListBinding.inflate(LayoutInflater.from(context), parent, false)
+        return TransactionViewHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: TransactionViewHolder, position: Int){
@@ -51,7 +48,9 @@ class TransactionAdapter(private val clickListener:(Transactions) -> Unit):
         }
     }
 
-    inner class TransactionViewHolder(view: RecentTransactionListBinding): RecyclerView.ViewHolder(view.root) {
+    inner class TransactionViewHolder(
+        private val view: RecentTransactionListBinding
+    ): RecyclerView.ViewHolder(view.root) {
         fun bind(transactionAttributes: Transactions, clickListener: (Transactions) -> Unit){
             val sharedPref = context.getSharedPreferences(
                 context.getUniqueHash().toString() + "-user-preferences", Context.MODE_PRIVATE)
@@ -59,25 +58,25 @@ class TransactionAdapter(private val clickListener:(Transactions) -> Unit):
             val userDefinedDateTime = AppPref(sharedPref).userDefinedDateTimeFormat
             val transactionDescription = transactionAttributes.description
             val descriptionText = if(transactionAttributes.isPending){
-                binding.transactionNameText.setTextColor(context.getCompatColor(R.color.md_red_500))
+                view.transactionNameText.setTextColor(context.getCompatColor(R.color.md_red_500))
                 "$transactionDescription (Pending)"
             } else {
                 transactionDescription
             }
-            binding.transactionNameText.text = descriptionText
-            binding.sourceNameText.text = transactionAttributes.source_name
-            binding.transactionJournalId.text = transactionAttributes.transaction_journal_id.toString()
-            binding.dateText.text = DateTimeUtil.convertLocalDateTime(transactionAttributes.date , timePreference, userDefinedDateTime)
+            view.transactionNameText.text = descriptionText
+            view.sourceNameText.text = transactionAttributes.source_name
+            view.transactionJournalId.text = transactionAttributes.transaction_journal_id.toString()
+            view.dateText.text = DateTimeUtil.convertLocalDateTime(transactionAttributes.date , timePreference, userDefinedDateTime)
             if(transactionAttributes.amount.toString().startsWith("-")){
                 // Negative value means it's a withdrawal
-                binding.transactionAmountText.setTextColor(context.getCompatColor(R.color.md_red_500))
-                binding.transactionAmountText.text = "-" + transactionAttributes.currency_symbol +
+                view.transactionAmountText.setTextColor(context.getCompatColor(R.color.md_red_500))
+                view.transactionAmountText.text = "-" + transactionAttributes.currency_symbol +
                         Math.abs(transactionAttributes.amount)
             } else {
-                binding.transactionAmountText.text = transactionAttributes.currency_symbol +
+                view.transactionAmountText.text = transactionAttributes.currency_symbol +
                         transactionAttributes.amount.toString()
             }
-            binding.listItem.setOnClickListener {clickListener(transactionAttributes)}
+            view.listItem.setOnClickListener {clickListener(transactionAttributes)}
         }
     }
 

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionMonthRecyclerView.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionMonthRecyclerView.kt
@@ -32,14 +32,12 @@ class TransactionMonthRecyclerView(private val items: List<TransactionAmountMont
         RecyclerView.Adapter<TransactionMonthRecyclerView.TransactionAdapter>() {
 
     private lateinit var context: Context
-    private var transactionCardDetails: TransactionCardDetailsBinding? = null
-    private val binding get() = transactionCardDetails!!
 
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TransactionAdapter {
         context = parent.context
-        transactionCardDetails = TransactionCardDetailsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return TransactionAdapter(binding)
+        val itemView = TransactionCardDetailsBinding.inflate(LayoutInflater.from(context), parent, false)
+        return TransactionAdapter(itemView)
     }
 
     override fun getItemCount() = items.size
@@ -47,22 +45,24 @@ class TransactionMonthRecyclerView(private val items: List<TransactionAmountMont
     override fun onBindViewHolder(holder: TransactionAdapter, position: Int) = holder.bind(items[position], position)
 
 
-    inner class TransactionAdapter(view: TransactionCardDetailsBinding): RecyclerView.ViewHolder(view.root) {
+    inner class TransactionAdapter(
+        private val view: TransactionCardDetailsBinding
+    ): RecyclerView.ViewHolder(view.root) {
         fun bind(transactionData: TransactionAmountMonth, click: Int) {
-            binding.transactionFreq.text = transactionData.transactionFreq.toString()
-            binding.spentAmount.text = transactionData.transactionAmount
-            binding.transactionCardDate.text = transactionData.monthYear
+            view.transactionFreq.text = transactionData.transactionFreq.toString()
+            view.spentAmount.text = transactionData.transactionAmount
+            view.transactionCardDate.text = transactionData.monthYear
             if(transactionData.transactionType.contentEquals("Withdrawal")){
-                binding.transactionTypeText.setText(R.string.spent)
-                binding.spentAmount.setTextColor(context.getCompatColor(R.color.md_red_500))
+                view.transactionTypeText.setText(R.string.spent)
+                view.spentAmount.setTextColor(context.getCompatColor(R.color.md_red_500))
             } else if(transactionData.transactionType.contentEquals("Deposit")){
-                binding.transactionTypeText.setText(R.string.earned)
-                binding.spentAmount.setTextColor(context.getCompatColor(R.color.md_green_500))
+                view.transactionTypeText.setText(R.string.earned)
+                view.spentAmount.setTextColor(context.getCompatColor(R.color.md_green_500))
             } else {
-                binding.transactionTypeText.setText(R.string.transfer)
-                binding.spentAmount.setTextColor(context.getCompatColor(R.color.md_green_500))
+                view.transactionTypeText.setText(R.string.transfer)
+                view.spentAmount.setTextColor(context.getCompatColor(R.color.md_green_500))
             }
-            binding.root.setOnClickListener { clickListener(click) }
+            view.root.setOnClickListener { clickListener(click) }
         }
     }
 

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionSeparatorAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/TransactionSeparatorAdapter.kt
@@ -36,24 +36,19 @@ import xyz.hisname.fireflyiii.util.getUniqueHash
 import kotlin.math.abs
 
 class TransactionSeparatorAdapter(private val clickListener:(Transactions) -> Unit):
-        PagingDataAdapter<SplitSeparator, RecyclerView.ViewHolder>(DIFF_CALLBACK){
+        PagingDataAdapter<SplitSeparator, RecyclerView.ViewHolder>(DIFF_CALLBACK) {
 
     private lateinit var context: Context
-    private var recentTransactionListBinding: RecentTransactionListBinding? = null
-    private val binding get() = recentTransactionListBinding!!
-    private var transactionItemSeparatorBinding: TransactionItemSeparatorBinding? = null
-    private val separatorBinding get() = transactionItemSeparatorBinding!!
-
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         context = parent.context
         return when(viewType){
             R.layout.recent_transaction_list -> {
-                recentTransactionListBinding = RecentTransactionListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                val binding = RecentTransactionListBinding.inflate(LayoutInflater.from(context), parent, false)
                 TransactionViewHolder(binding)
             }
             else -> {
-                transactionItemSeparatorBinding = TransactionItemSeparatorBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                val separatorBinding = TransactionItemSeparatorBinding.inflate(LayoutInflater.from(context), parent, false)
                 SplitSeparatorViewHolder(separatorBinding)
             }
         }
@@ -73,10 +68,13 @@ class TransactionSeparatorAdapter(private val clickListener:(Transactions) -> Un
         transactionModel.let { separator ->
             when(separator){
                 is SplitSeparator.SeparatorItem -> {
+                    val viewHolder = holder as SplitSeparatorViewHolder
+                    val separatorBinding = viewHolder.view
                     separatorBinding.separatorDescription.text = separator.description
                 }
                 is SplitSeparator.TransactionItem -> {
                     val viewHolder = holder as TransactionViewHolder
+                    val binding = viewHolder.view
                     val sharedPref = context.getSharedPreferences(
                         context.getUniqueHash().toString() + "-user-preferences", Context.MODE_PRIVATE)
                     val timePreference = AppPref(sharedPref).dateTimeFormat
@@ -109,8 +107,12 @@ class TransactionSeparatorAdapter(private val clickListener:(Transactions) -> Un
     }
 
 
-    class TransactionViewHolder(view: RecentTransactionListBinding) : RecyclerView.ViewHolder(view.root)
-    class SplitSeparatorViewHolder(view: TransactionItemSeparatorBinding) : RecyclerView.ViewHolder(view.root)
+    class TransactionViewHolder(
+        val view: RecentTransactionListBinding
+    ) : RecyclerView.ViewHolder(view.root)
+    class SplitSeparatorViewHolder(
+        val view: TransactionItemSeparatorBinding
+    ) : RecyclerView.ViewHolder(view.root)
 
 
     companion object {

--- a/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/search/DescriptionAdapter.kt
+++ b/app/src/main/java/xyz/hisname/fireflyiii/ui/transaction/search/DescriptionAdapter.kt
@@ -29,14 +29,10 @@ import xyz.hisname.fireflyiii.databinding.DescriptionListItemBinding
 class DescriptionAdapter(private val clickListener:(String) -> Unit):
         PagingDataAdapter<String, DescriptionAdapter.DescriptionViewHolder>(DIFF_CALLBACK) {
 
-    private lateinit var context: Context
-    private var descriptionListItemBinding: DescriptionListItemBinding? = null
-    private val binding get() = descriptionListItemBinding!!
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DescriptionViewHolder {
-        context = parent.context
-        descriptionListItemBinding = DescriptionListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return DescriptionViewHolder(binding)
+        val context = parent.context
+        val itemView = DescriptionListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return DescriptionViewHolder(itemView)
     }
 
     override fun onBindViewHolder(holder: DescriptionViewHolder, position: Int){
@@ -45,10 +41,12 @@ class DescriptionAdapter(private val clickListener:(String) -> Unit):
         }
     }
 
-    inner class DescriptionViewHolder(view: DescriptionListItemBinding): RecyclerView.ViewHolder(view.root) {
+    inner class DescriptionViewHolder(
+        private val view: DescriptionListItemBinding
+    ): RecyclerView.ViewHolder(view.root) {
         fun bind(description: String, clickListener: (String) -> Unit){
-            binding.description.text = description
-            binding.root.setOnClickListener {clickListener(description)}
+            view.description.text = description
+            view.root.setOnClickListener {clickListener(description)}
         }
     }
 


### PR DESCRIPTION
Fixes #203

## Type of change

- [X] Bug fix 
- [ ] New feature
- [ ] Translation

#203 appears to happen due to incorrect usage of the `RecyclerView`. After digging through the code I found that the same incorrect usage exists in other list-views as well (and I managed to reproduce the same bug in the other views as well). So this PR attempts to correct the usage in every place.

> When an item scrolls off the screen, RecyclerView doesn't destroy its view. Instead, RecyclerView reuses the view for new items that have scrolled onscreen. https://developer.android.com/guide/topics/ui/layout/recyclerview