### PR TITLE
Fix crashing on launch due to R8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,10 +21,10 @@ android {
         vectorDrawables.useSupportLibrary = true
         def appConfigFile = file('config.properties')
         def hostName = ""
-        if(appConfigFile.exists()){
+        if (appConfigFile.exists()) {
             Properties appConfig = new Properties()
             appConfig.load(new FileInputStream(appConfigFile))
-            if(appConfig['config.hostname'] != null){
+            if (appConfig['config.hostname'] != null) {
                 hostName = appConfig['config.hostname']
                 manifestPlaceholders = [host: hostName.replaceAll('"', '')]
             }
@@ -39,29 +39,28 @@ android {
     }
 
     buildTypes {
-         release {
-            postprocessing {
-                removeUnusedCode true
-                removeUnusedResources true
-                obfuscate false
-                optimizeCode true
-                proguardFiles = ['proguard-rules.pro']
-            }
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro"
+            )
         }
         debug {
             applicationIdSuffix '.debug'
             versionNameSuffix "-debug"
             minifyEnabled false
         }
-        // Do not use `JavaVersion.VERSION_11`! Will cause issues on `release` builds due to Proguard
-        // Needs more investigation before using 11.  See issue #192
-        compileOptions {
-            coreLibraryDesugaringEnabled true
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
-        kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
 
     buildFeatures {
         viewBinding true
@@ -75,7 +74,7 @@ android {
         }
     }
 
-    configurations {all*.exclude group: 'com.android.support'}
+    configurations { all*.exclude group: 'com.android.support' }
     androidResources {
         ignoreAssetsPattern 'NOTICE.txt'
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,4 @@
     public static **[] values();
     public static ** valueOf(java.lang.String);
 }
+-dontobfuscate


### PR DESCRIPTION
Fixes #235 

## Type of change

- [X] Bug fix 
- [ ] New feature
- [ ] Translation

This PR adds default proguard rules provided by Android SDK. Without these rules, important methods and classes get removed, for example Parcelable implementation of FragmentManagerState. Additional information can be found in https://github.com/streetcomplete/StreetComplete/issues/2003.

I tried to keep the configuration that was specified in postprocessing {} block as it is not compatible with default proguard rules. Let me know if there are any changes.

Also, I bumped Java version to 11 as the proguard issues reported in #192 should be fixed with default rules. I don't experience any crashes on release build with that setup.
